### PR TITLE
Helping update remember id

### DIFF
--- a/src/controllers/StationPanelController.php
+++ b/src/controllers/StationPanelController.php
@@ -491,6 +491,7 @@ class StationPanelController extends BaseController {
 
 		$panel		= new Panel;
 		$panel_data	= $panel->get_record_for($panel_name, $id, $this->subpanel_parent);
+		$panel_data['data']['id'] = (int)$id;
 
 		$method = 'U';
 


### PR DESCRIPTION
The get_record_for function doesn't pass back the proper id for the updated item, just the 1st record in that table. This fixes that.
